### PR TITLE
Support "unknown" animation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ Supported formats:
 ## Usage
 
 ```python
-from imgsize import get_size
+from imgsize import get_size, Size, Animation
 
 some_image_data: bytes = ...
 
-size = get_size(some_image_data)
+size: Size | None = get_size(some_image_data)
 if size is None:
     print("Could not handle data")
 else:
-    size.width
-    size.height
-    size.mime_type
-    size.is_animated
+    size.width: int
+    size.height: int
+    size.mime_type: str
+    size.animation: Animation
 ```
 
 You should not pass the entire image data, the first kilobyte or so should suffice for most formats, other than GIF
@@ -42,7 +42,7 @@ is an animated image or not, otherwise returns None.
 
 #### `imgsize.Size`
 
-A class with four properties: `width: int`, `height: int`, `mime_type: str`, `is_animated: bool`.
+A class with four properties: `width: int`, `height: int`, `mime_type: str`, `animation: Animation`.
 
 Instances of `imgsize.Size` are equatable, hashable and iterable (yielding `width` and `height`).
 

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -22,7 +22,7 @@ pub fn main() -> io::Result<()> {
         match imgsize::get_size(&buffer[..read]) {
             Some(size) => println!(
                 "{}: {}x{}, {}, animated={}",
-                name, size.width, size.height, size.mime_type, size.is_animated
+                name, size.width, size.height, size.mime_type, size.animation
             ),
             None => println!("{}: unsupported format", name),
         }

--- a/imgsize.pyi
+++ b/imgsize.pyi
@@ -1,19 +1,24 @@
 from typing import Any, Iterable, TypedDict
 
+class Animation:
+    class Yes: ...
+    class No: ...
+    class Unknown: ...
+
 class SizeDict(TypedDict):
     width: int
     height: int
     mime_type: int
-    is_animated: int
+    animation: Animation
 
 class Size:
     width: int
     height: int
     mime_type: int
-    is_animated: int
+    animation: Animation
 
     def __init__(
-        self, width: int, height: int, mime_type: str, is_animated: bool
+        self, width: int, height: int, mime_type: str, animation: Animation
     ) -> None: ...
     def as_dict(self) -> SizeDict: ...
     def __repr__(self) -> str: ...

--- a/python-tests/test_apis.py
+++ b/python-tests/test_apis.py
@@ -1,10 +1,20 @@
 def test_eq(imgsize):
-    assert imgsize.Size(1, 2, "a", True) == imgsize.Size(1, 2, "a", True)
-    assert imgsize.Size(1, 2, "a", True) != imgsize.Size(2, 2, "a", True)
-    assert imgsize.Size(1, 2, "a", True) != imgsize.Size(1, 1, "a", True)
-    assert imgsize.Size(1, 2, "a", True) != imgsize.Size(1, 2, "b", True)
-    assert imgsize.Size(1, 2, "a", True) != imgsize.Size(1, 2, "a", False)
+    assert imgsize.Size(1, 2, "a", imgsize.Animation.Yes) == imgsize.Size(
+        1, 2, "a", imgsize.Animation.Yes
+    )
+    assert imgsize.Size(1, 2, "a", imgsize.Animation.Yes) != imgsize.Size(
+        2, 2, "a", imgsize.Animation.Yes
+    )
+    assert imgsize.Size(1, 2, "a", imgsize.Animation.Yes) != imgsize.Size(
+        1, 1, "a", imgsize.Animation.Yes
+    )
+    assert imgsize.Size(1, 2, "a", imgsize.Animation.Yes) != imgsize.Size(
+        1, 2, "b", imgsize.Animation.Yes
+    )
+    assert imgsize.Size(1, 2, "a", imgsize.Animation.Yes) != imgsize.Size(
+        1, 2, "a", imgsize.Animation.No
+    )
 
 
 def test_iter(imgsize):
-    assert list(imgsize.Size(1, 2, "a", True)) == [1, 2]
+    assert list(imgsize.Size(1, 2, "a", imgsize.Animation.Yes)) == [1, 2]

--- a/python-tests/test_sample_files.py
+++ b/python-tests/test_sample_files.py
@@ -14,7 +14,9 @@ def find_examples():
             data = fobj.read()
         with output_path.open("r") as fobj:
             output = json.load(fobj)
-        yield pytest.param(data, remove_comments(output), id=input_path.stem)
+        yield pytest.param(
+            data, fix_output(remove_comments(output)), id=input_path.stem
+        )
 
 
 def remove_comments(data):
@@ -22,6 +24,22 @@ def remove_comments(data):
     return data
 
 
+def fix_output(data):
+    return lambda imgsize: data | {"animation": animation(imgsize, data["animation"])}
+
+
+def animation(imgsize, v):
+    match v:
+        case True | "yes":
+            return imgsize.Animation.Yes
+        case False | "no":
+            return imgsize.Animation.No
+        case "unknown":
+            return imgsize.Animation.Unknown
+        case _ as value:
+            assert False, "unexpected value: {value!r}".format(value=value)
+
+
 @pytest.mark.parametrize("input,output", find_examples())
 def test_sample_files(input, output, imgsize):
-    assert imgsize.get_size(input).as_dict() == output
+    assert imgsize.get_size(input).as_dict() == output(imgsize)

--- a/src/avif.rs
+++ b/src/avif.rs
@@ -21,7 +21,7 @@ pub fn get_size(data: &[u8]) -> Option<Size> {
         width as u64,
         height as u64,
         MIME_TYPE.to_string(),
-        animated,
+        animated.into(),
     ))
 }
 

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -3,7 +3,7 @@ use std::io::{Seek, SeekFrom};
 use byteorder::{LittleEndian, ReadBytesExt};
 
 use crate::utils::cursor_parser;
-use crate::Size;
+use crate::{Animation, Size};
 
 const MIME_TYPE: &str = "image/bmp";
 
@@ -19,7 +19,7 @@ pub fn get_size(data: &[u8]) -> Option<Size> {
                     width as u64,
                     height as u64,
                     MIME_TYPE.to_string(),
-                    false,
+                    Animation::No,
                 )))
             }
             40 | 64 | 108 | 124 => {
@@ -29,7 +29,12 @@ pub fn get_size(data: &[u8]) -> Option<Size> {
                 if cursor.read_u8()? == 0xff {
                     height = 4294967296 - height;
                 }
-                Ok(Some(Size::new(width, height, MIME_TYPE.to_string(), false)))
+                Ok(Some(Size::new(
+                    width,
+                    height,
+                    MIME_TYPE.to_string(),
+                    Animation::No,
+                )))
             }
             _ => Ok(None),
         }

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -4,7 +4,7 @@ use std::io::{Cursor, Seek, SeekFrom};
 use byteorder::{LittleEndian, ReadBytesExt};
 
 use crate::utils::cursor_parser;
-use crate::Size;
+use crate::{Animation, Size};
 
 const MIME_TYPE: &str = "image/gif";
 
@@ -22,67 +22,79 @@ pub fn get_size(data: &[u8]) -> Option<Size> {
             // skip Global Color Table
             cursor.seek(SeekFrom::Current(size))?;
         }
-        let mut found_image = false;
-        let mut gce_found = false;
-        loop {
-            match cursor.read_u8()? {
-                // Image Descriptor
-                0x2c => {
-                    if found_image {
-                        return Ok(Some(Size::new(width, height, MIME_TYPE.to_string(), true)));
-                    } else if !gce_found {
-                        return Ok(Some(Size::new(width, height, MIME_TYPE.to_string(), false)));
-                    }
-                    found_image = true;
-                    cursor.seek(SeekFrom::Current(8))?;
-                    let flags = cursor.read_u8()?;
-                    if let Some(size) = color_table_size(flags) {
-                        cursor.seek(SeekFrom::Current(size))?;
-                    }
-                    // skip LZW Minimum Code Size
-                    cursor.seek(SeekFrom::Current(1))?;
-                    skip_data_sub_blocks(&mut cursor)?;
+        let animation = detect_animation(&mut cursor)?;
+        Ok(animation.map(|animation| Size::new(width, height, MIME_TYPE.to_string(), animation)))
+    })
+}
+
+fn detect_animation(cursor: &mut Cursor<&[u8]>) -> io::Result<Option<Animation>> {
+    match detect_animation_inner(cursor) {
+        Ok(animation) => Ok(animation.map(|a| a.into())),
+        Err(_) => Ok(Some(Animation::Unknown)),
+    }
+}
+
+fn detect_animation_inner(cursor: &mut Cursor<&[u8]>) -> io::Result<Option<bool>> {
+    let mut found_image = false;
+    let mut gce_found = false;
+    loop {
+        match cursor.read_u8()? {
+            // Image Descriptor
+            0x2c => {
+                if found_image {
+                    return Ok(Some(true));
+                } else if !gce_found {
+                    return Ok(Some(false));
                 }
-                // Extension
-                0x21 => match cursor.read_u8()? {
-                    // Graphic Control Extension
-                    0xf9 => {
-                        gce_found = true;
-                        // skip block size (always 4) and extension data
-                        cursor.seek(SeekFrom::Current(5))?;
-                        skip_data_sub_blocks(&mut cursor)?;
-                    }
-                    // Comment Extension
-                    0xfe => {
-                        skip_data_sub_blocks(&mut cursor)?;
-                    }
-                    // Plain Text Extension
-                    0x01 => {
-                        // skip block size (always 12) and extension data
-                        cursor.seek(SeekFrom::Current(13))?;
-                        skip_data_sub_blocks(&mut cursor)?;
-                    }
-                    // Application Extension
-                    0xff => {
-                        // skip block size (always 11) and extension data
-                        cursor.seek(SeekFrom::Current(12))?;
-                        skip_data_sub_blocks(&mut cursor)?;
-                    }
-                    _ => {
-                        return Ok(None);
-                    }
-                },
-                // Trailer
-                0x3B => {
-                    if found_image {
-                        return Ok(Some(Size::new(width, height, MIME_TYPE.to_string(), false)));
-                    }
+                found_image = true;
+                cursor.seek(SeekFrom::Current(8))?;
+                let flags = cursor.read_u8()?;
+                if let Some(size) = color_table_size(flags) {
+                    cursor.seek(SeekFrom::Current(size))?;
+                }
+                // skip LZW Minimum Code Size
+                cursor.seek(SeekFrom::Current(1))?;
+                skip_data_sub_blocks(cursor)?;
+            }
+            // Extension
+            0x21 => match cursor.read_u8()? {
+                // Graphic Control Extension
+                0xf9 => {
+                    gce_found = true;
+                    // skip block size (always 4) and extension data
+                    cursor.seek(SeekFrom::Current(5))?;
+                    skip_data_sub_blocks(cursor)?;
+                }
+                // Comment Extension
+                0xfe => {
+                    skip_data_sub_blocks(cursor)?;
+                }
+                // Plain Text Extension
+                0x01 => {
+                    // skip block size (always 12) and extension data
+                    cursor.seek(SeekFrom::Current(13))?;
+                    skip_data_sub_blocks(cursor)?;
+                }
+                // Application Extension
+                0xff => {
+                    // skip block size (always 11) and extension data
+                    cursor.seek(SeekFrom::Current(12))?;
+                    skip_data_sub_blocks(cursor)?;
+                }
+                _ => {
                     return Ok(None);
                 }
-                _ => return Ok(None),
+            },
+            // Trailer
+            0x3B => {
+                if found_image {
+                    return Ok(Some(false));
+                }
+                return Ok(None);
             }
+            _ => return Ok(None),
         }
-    })
+    }
 }
 
 fn color_table_size(flags: u8) -> Option<i64> {

--- a/src/jpg.rs
+++ b/src/jpg.rs
@@ -3,7 +3,7 @@ use std::io::{Seek, SeekFrom};
 use byteorder::{BigEndian, ReadBytesExt};
 
 use crate::utils::cursor_parser;
-use crate::Size;
+use crate::{Animation, Size};
 
 const MIME_TYPE: &str = "image/jpeg";
 const START_OF_FRAMES: [u8; 13] = [
@@ -23,7 +23,7 @@ pub fn get_size(data: &[u8]) -> Option<Size> {
                     width as u64,
                     height as u64,
                     MIME_TYPE.to_string(),
-                    false,
+                    Animation::No,
                 )));
             } else {
                 let length = cursor.read_u16::<BigEndian>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,37 +10,60 @@ use pyo3::types::PyDict;
 #[cfg(test)]
 use serde::Deserialize;
 use std::array::IntoIter;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+use std::fmt::{Display, Formatter};
 
-#[pyclass(get_all)]
+#[pyclass(eq, eq_int)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+pub enum Animation {
+    Yes,
+    No,
+    Unknown,
+}
+
+impl From<bool> for Animation {
+    fn from(value: bool) -> Self {
+        if value {
+            Self::Yes
+        } else {
+            Self::No
+        }
+    }
+}
+
+impl Display for Animation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Animation::Yes => "yes",
+            Animation::No => "no",
+            Animation::Unknown => "unknown",
+        })
+    }
+}
+
+#[pyclass(get_all, eq, hash, frozen)]
 #[derive(Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(Deserialize))]
 pub struct Size {
     pub width: u64,
     pub height: u64,
     pub mime_type: String,
-    pub is_animated: bool,
+    pub animation: Animation,
 }
 
 #[pymethods]
 impl Size {
     #[new]
-    fn new(width: u64, height: u64, mime_type: String, is_animated: bool) -> Self {
+    fn new(width: u64, height: u64, mime_type: String, animation: Animation) -> Self {
         Self {
             width,
             height,
             mime_type,
-            is_animated,
+            animation,
         }
     }
 
     fn __repr__(&self) -> String {
         format!("{:?}", self)
-    }
-
-    fn __eq__(&self, other: &Self) -> bool {
-        self == other
     }
 
     fn __iter__(slf: PyRef<'_, Self>) -> PyResult<Py<SizeIter>> {
@@ -50,19 +73,13 @@ impl Size {
         Py::new(slf.py(), itr)
     }
 
-    fn __hash__(&self) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        self.hash(&mut hasher);
-        hasher.finish()
-    }
-
     fn as_dict(&self) -> PyResult<Py<PyDict>> {
         Python::attach(|py| {
             let dict = PyDict::new(py);
             dict.set_item("width", self.width)?;
             dict.set_item("height", self.height)?;
             dict.set_item("mime_type", self.mime_type.clone())?;
-            dict.set_item("is_animated", self.is_animated)?;
+            dict.set_item("animation", self.animation.clone())?;
             Ok(dict.unbind())
         })
     }
@@ -111,6 +128,7 @@ fn py_get_size(data: &[u8]) -> PyResult<Option<Size>> {
 fn imgsize(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_get_size, m)?)?;
     m.add_class::<Size>()?;
+    m.add_class::<Animation>()?;
     Ok(())
 }
 
@@ -118,8 +136,48 @@ fn imgsize(m: &Bound<'_, PyModule>) -> PyResult<()> {
 mod tests {
     use super::*;
     use paste::paste;
+    use serde::{de, Deserialize, Deserializer};
     use std::collections::HashSet;
+    use std::fmt::Formatter;
     use std::path::Path;
+
+    struct AnimationVisitor;
+
+    impl<'de> de::Visitor<'de> for AnimationVisitor {
+        type Value = Animation;
+
+        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            formatter.write_str("'yes', 'no' or 'unknown' or a boolean")
+        }
+
+        fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Animation::from(v))
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            match v {
+                "yes" => Ok(Animation::Yes),
+                "no" => Ok(Animation::No),
+                "unknown" => Ok(Animation::Unknown),
+                _ => Err(E::custom(format!("Unexpected value: {}", v))),
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Animation {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_any(AnimationVisitor)
+        }
+    }
 
     macro_rules! define_tests {
         (impl $name:ident) => {

--- a/src/test-data/apng.output
+++ b/src/test-data/apng.output
@@ -2,5 +2,5 @@
     "width": 100,
     "height": 100,
     "mime_type": "image/png",
-    "is_animated": true
+    "animation": true
 }

--- a/src/test-data/avif.output
+++ b/src/test-data/avif.output
@@ -2,5 +2,5 @@
   "width": 1203,
   "height": 799,
   "mime_type": "image/avif",
-  "is_animated": false
+  "animation": false
 }

--- a/src/test-data/avis.output
+++ b/src/test-data/avis.output
@@ -2,5 +2,5 @@
   "width": 480,
   "height": 270,
   "mime_type": "image/avif",
-  "is_animated": true
+  "animation": true
 }

--- a/src/test-data/bmp.output
+++ b/src/test-data/bmp.output
@@ -2,5 +2,5 @@
     "width": 512,
     "height": 512,
     "mime_type": "image/bmp",
-    "is_animated": false
+    "animation": false
 }

--- a/src/test-data/gif.output
+++ b/src/test-data/gif.output
@@ -2,6 +2,6 @@
   "width": 250,
   "height": 297,
   "mime_type": "image/gif",
-  "is_animated": false,
+  "animation": false,
   "comment": "non animated gif without Application Extension or Graphic Control Extension"
 }

--- a/src/test-data/gif2.output
+++ b/src/test-data/gif2.output
@@ -2,6 +2,6 @@
   "width": 250,
   "height": 297,
   "mime_type": "image/gif",
-  "is_animated": false,
+  "animation": false,
   "comment": "non animated gif with Application Extension or Graphic Control Extension but only a single image"
 }

--- a/src/test-data/gifanim.output
+++ b/src/test-data/gifanim.output
@@ -2,5 +2,5 @@
   "width": 400,
   "height": 400,
   "mime_type": "image/gif",
-  "is_animated": true
+  "animation": true
 }

--- a/src/test-data/gifanim2.output
+++ b/src/test-data/gifanim2.output
@@ -2,5 +2,5 @@
   "width": 198,
   "height": 57,
   "mime_type": "image/gif",
-  "is_animated": true
+  "animation": true
 }

--- a/src/test-data/jpeg.output
+++ b/src/test-data/jpeg.output
@@ -2,5 +2,5 @@
   "width": 800,
   "height":450,
   "mime_type": "image/jpeg",
-  "is_animated": false
+  "animation": false
 }

--- a/src/test-data/jpg.output
+++ b/src/test-data/jpg.output
@@ -2,5 +2,5 @@
   "width": 313,
   "height": 234,
   "mime_type": "image/jpeg",
-  "is_animated": false
+  "animation": false
 }

--- a/src/test-data/png.output
+++ b/src/test-data/png.output
@@ -2,5 +2,5 @@
   "width": 800,
   "height": 600,
   "mime_type": "image/png",
-  "is_animated": false
+  "animation": false
 }


### PR DESCRIPTION
GIF might require reading deeply into the data stream to conclusively decide whether an image is animated or not. This change allows "unknown" animation statuses, for the case where we found the image type/dimensions but have not enough data to conclusively say whether it's animated or not.